### PR TITLE
remove jail_path from "pkg -j"

### DIFF
--- a/check_ports
+++ b/check_ports
@@ -352,7 +352,7 @@ run_main_jail() {
       UPDATES_LIST=$(PKG_DBDIR=${JAIL_PATH}/var/db/pkg ${PKG_VERSION} ${PKGVERSION_OPTS} ${JAIL_PATH}${PORTINDEX} | grep "needs updating" | awk '{ print $1 " " $5 " " $6 " " $7 }')
       UPDATES=$(echo "${UPDATES_LIST}" | grep -c .)
     else
-      UPDATES_LIST=$(${PKG} -j ${JID} ${PKG_OPTS} ${JAIL_PATH}${PORTINDEX} | grep "needs updating" | awk '{ print $1 " " $5 " " $6 " " $7 }')
+      UPDATES_LIST=$(${PKG} -j ${JID} ${PKG_OPTS} ${PORTINDEX} | grep "needs updating" | awk '{ print $1 " " $5 " " $6 " " $7 }')
       UPDATES=$(echo "${UPDATES_LIST}" | grep -c .)
     fi
   fi


### PR DESCRIPTION
If I want to check a jail (`check_ports -wp -j some_jail`), I got this error:

> pkg: Can't access /usr/jails/some_jail/usr/ports/INDEX-10: No such file or directory
PORTS OK - 0 security problem(s), 0 Package(s) available for upgrade, Ports Tree updated within the last 24h. | total_updates=0;0;0 security_problems=0;0;0